### PR TITLE
feat: sealed classes

### DIFF
--- a/sample-package/src/main/kotlin/digital/guimauve/example/Payload.kt
+++ b/sample-package/src/main/kotlin/digital/guimauve/example/Payload.kt
@@ -1,0 +1,17 @@
+package digital.guimauve.example
+
+import digital.guimauve.zodable.Zodable
+import kotlinx.serialization.SerialName
+
+@Zodable
+sealed class Payload {
+
+    @SerialName("EMPTY")
+    data object EmptyPayload : Payload()
+
+    @SerialName("TEXT")
+    data class TextPayload(
+        val text: String,
+    ) : Payload()
+
+}

--- a/zodable-ksp-processor/src/main/kotlin/digital/guimauve/zodable/generators/ZodableGenerator.kt
+++ b/zodable-ksp-processor/src/main/kotlin/digital/guimauve/zodable/generators/ZodableGenerator.kt
@@ -37,32 +37,17 @@ abstract class ZodableGenerator(
                     zodOverride.content.trimIndent()
                 }
 
-                val generatedBody = overriddenSchema ?: when (classDeclaration.classKind) {
-                    ClassKind.ENUM_CLASS -> {
-                        val values = classDeclaration.declarations.filterIsInstance<KSClassDeclaration>()
-                            .map { it.simpleName.asString() }
-                            .toSet()
-                        generateEnumSchema(name, arguments, values)
-                    }
+                val sealedSubclasses = try {
+                    classDeclaration.getSealedSubclasses().toList()
+                } catch (_: Exception) {
+                    emptyList()
+                }
 
-                    else -> {
-                        val properties = classDeclaration.getAllProperties()
-                            .filter { it.hasBackingField }
-                            .mapNotNull { prop ->
-                                val name = prop.annotations.firstNotNullOfOrNull { annotation ->
-                                    if (annotation.shortName.asString() != SerialName::class.simpleName) return@firstNotNullOfOrNull null
-                                    annotation.toSerialName().value
-                                } ?: prop.simpleName.asString()
-                                val (type, localImports) = resolveZodType(prop, classDeclaration)
-                                    ?: return@mapNotNull null
-                                localImports.forEach { import ->
-                                    if (imports.none { it.name == import.name }) imports.add(import)
-                                }
-                                name to type
-                            }
-                            .toSet()
-                        generateClassSchema(name, arguments, properties)
-                    }
+                val generatedBody = overriddenSchema ?: if (sealedSubclasses.isNotEmpty()) {
+                    processSealedClass(name, arguments, sealedSubclasses, imports)
+                } else when (classDeclaration.classKind) {
+                    ClassKind.ENUM_CLASS -> processEnumClass(name, arguments, classDeclaration)
+                    else -> processClass(name, arguments, classDeclaration, imports)
                 }
                 val generatedImports = generateImports(sourceFolder, classFile, imports) + "\n"
 
@@ -84,6 +69,69 @@ abstract class ZodableGenerator(
         }
     }
 
+    private fun processEnumClass(name: String, arguments: List<String>, classDeclaration: KSClassDeclaration): String {
+        val values = classDeclaration.declarations.filterIsInstance<KSClassDeclaration>()
+            .map { it.simpleName.asString() }
+            .toSet()
+        return generateEnumSchema(name, arguments, values)
+    }
+
+    private fun processSealedClass(
+        name: String,
+        arguments: List<String>,
+        subclasses: List<KSClassDeclaration>,
+        imports: MutableSet<Import>,
+    ): String {
+        val variants = subclasses.associate { subclass ->
+            // Get the SerialName annotation value to use as the discriminator value
+            val subclassName = subclass.simpleName.asString()
+            val serialName = subclass.annotations.firstNotNullOfOrNull { annotation ->
+                if (annotation.shortName.asString() != "SerialName") return@firstNotNullOfOrNull null
+                val args = annotation.arguments.associateBy { it.name?.asString() }
+                args["value"]?.value as? String
+            } ?: subclass.simpleName.asString()
+            val subclassArguments = subclass.typeParameters.map { it.name.asString() }
+            val (literalType, literalImports) = resolveLiteralType(serialName)
+            imports.addAll(literalImports)
+
+            subclassName to processClass(
+                name = subclassName,
+                arguments = subclassArguments,
+                classDeclaration = subclass,
+                imports = imports,
+                additionalProperties = setOf("type" to literalType),
+            )
+        }
+        val union = generateUnionSchema(name, arguments, variants.keys)
+
+        return variants.values.joinToString("\n\n") + "\n\n" + union
+    }
+
+    private fun processClass(
+        name: String,
+        arguments: List<String>,
+        classDeclaration: KSClassDeclaration,
+        imports: MutableSet<Import>,
+        additionalProperties: Set<Pair<String, String>> = emptySet(),
+    ): String {
+        val properties = classDeclaration.getAllProperties()
+            .filter { it.hasBackingField }
+            .mapNotNull { prop ->
+                val name = prop.annotations.firstNotNullOfOrNull { annotation ->
+                    if (annotation.shortName.asString() != SerialName::class.simpleName) return@firstNotNullOfOrNull null
+                    annotation.toSerialName().value
+                } ?: prop.simpleName.asString()
+                val (type, localImports) = resolveZodType(prop, classDeclaration)
+                    ?: return@mapNotNull null
+                localImports.forEach { import ->
+                    if (imports.none { it.name == import.name }) imports.add(import)
+                }
+                name to type
+            }
+            .toSet()
+        return generateClassSchema(name, arguments, properties + additionalProperties)
+    }
+
     private fun generateImports(classDeclaration: KSClassDeclaration): Set<Import> =
         resolveDefaultImports(classDeclaration) + classDeclaration.annotations.mapNotNull { annotation ->
             if (annotation.shortName.asString() != ZodImport::class.simpleName) return@mapNotNull null
@@ -92,7 +140,7 @@ abstract class ZodableGenerator(
             Import(zodImport.name, zodImport.source, true, zodImport.isInvariable)
         }.toSet()
 
-    private fun resolveZodType(
+    protected fun resolveZodType(
         prop: KSPropertyDeclaration,
         classDeclaration: KSClassDeclaration,
     ): Pair<String, List<Import>>? {
@@ -112,7 +160,7 @@ abstract class ZodableGenerator(
         return resolveZodType(prop.type.resolve(), classDeclaration)
     }
 
-    private fun resolveZodType(type: KSType, classDeclaration: KSClassDeclaration): Pair<String, List<Import>> {
+    protected fun resolveZodType(type: KSType, classDeclaration: KSClassDeclaration): Pair<String, List<Import>> {
         val isNullable = type.isMarkedNullable
         val imports = mutableListOf<Import>()
 
@@ -210,8 +258,10 @@ abstract class ZodableGenerator(
     ): String
 
     abstract fun generateEnumSchema(name: String, arguments: List<String>, values: Set<String>): String
+    abstract fun generateUnionSchema(name: String, arguments: List<String>, values: Set<String>): String
     abstract fun resolvePrimitiveType(kotlinType: String): Pair<String, List<Import>>?
     abstract fun resolveZodableType(name: String, isGeneric: Boolean): Pair<String, List<Import>>
+    abstract fun resolveLiteralType(name: String): Pair<String, List<Import>>
     abstract fun resolveGenericArgument(name: String): Pair<String, List<Import>>
     abstract fun resolveUnknownType(): Pair<String, List<Import>>
     abstract fun addGenericArguments(type: String, arguments: List<String>): Pair<String, List<Import>>


### PR DESCRIPTION
Fixes #14 

Example (available in `sample-package`):

```kotlin
@Zodable
sealed class Payload {

    @SerialName("EMPTY")
    data object EmptyPayload : Payload()

    @SerialName("TEXT")
    data class TextPayload(
        val text: String,
    ) : Payload()

}
```

Generated schemas:

```typescript
export const EmptyPayloadSchema = z.object({
    type: z.literal("EMPTY")
})
export type EmptyPayload = z.infer<typeof EmptyPayloadSchema>

export const TextPayloadSchema = z.object({
    text: z.string(),
    type: z.literal("TEXT")
})
export type TextPayload = z.infer<typeof TextPayloadSchema>

export const PayloadSchema = z.discriminatedUnion("type", [
    EmptyPayloadSchema,
    TextPayloadSchema
])
export type Payload = z.infer<typeof PayloadSchema>
```

```python
class EmptyPayload(BaseModel):
    type: Literal["EMPTY"]

class TextPayload(BaseModel):
    text: str
    type: Literal["TEXT"]

Payload = Union[EmptyPayload, TextPayload]
```
