### PR TITLE
Improve unsupported type warning with containing class

### DIFF
--- a/zodable-ksp-processor/src/main/kotlin/digital/guimauve/zodable/generators/ZodableGenerator.kt
+++ b/zodable-ksp-processor/src/main/kotlin/digital/guimauve/zodable/generators/ZodableGenerator.kt
@@ -186,7 +186,7 @@ abstract class ZodableGenerator(
                 resolveGenericArgument(type.declaration.simpleName.asString())
             } else {
                 val unknownType = resolveUnknownType()
-                env.logger.warn("Unsupported type ${type.declaration.simpleName.asString()}, using ${unknownType.first}")
+                env.logger.warn("Unsupported type ${type.declaration.simpleName.asString()} in class ${classDeclaration.qualifiedName?.asString()}, using ${unknownType.first}")
                 unknownType
             }
         }()


### PR DESCRIPTION
Add the containing class to the unsupported type warning, to make it easier to fix.