### PR TITLE
fix: generate es modules instead of commonjs for npm packages

### DIFF
--- a/zodable-gradle-plugin/src/main/kotlin/digital/guimauve/zodable/ZodablePlugin.kt
+++ b/zodable-gradle-plugin/src/main/kotlin/digital/guimauve/zodable/ZodablePlugin.kt
@@ -153,8 +153,8 @@ abstract class ZodablePlugin : Plugin<Project> {
                             listOf(
                                 "npx", "tsc", "--init",
                                 "-d",
-                                "--module", "ES2020",
-                                "--moduleResolution", "node",
+                                "--module", "esnext",
+                                "--moduleResolution", "bundler",
                                 "--baseUrl", "./",
                                 "--isolatedModules", "false",
                                 "--verbatimModuleSyntax", "false"


### PR DESCRIPTION
Fixes #35 